### PR TITLE
Bringing in McPhail's WIP

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
     Brewtarget is FREE brewing software, and an open source beer recipe creation tool. It automatically calculates color, bitterness, and more for you while you drag and drop ingredients into the recipe. Brewtarget also has many other tools such as priming sugar calculators, OG correction help, and a unique mash designing tool. It can export and import recipes, allowing you to easily share them with friends. All of this means that Brewtarget is your single, free, go-to tool when crafting your beer recipes.
 #icon:
 grade: devel # must be 'stable' to release into candidate/stable channels
-confinement: devmode # use 'strict' once you have the right plugs and slots
+confinement: strict # use 'strict' once you have the right plugs and slots
 
 apps:
   padraic-brewtarget:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,7 @@ apps:
       - wayland
       - x11
       - unity7
+      - opengl
 
 parts:
 # The session-manager-workaround launcher: Silent error messages due to inaccessible paths
@@ -39,6 +40,9 @@ parts:
     plugin: cmake
     build-packages: [g++, cmake, git, qtbase5-dev, qttools5-dev, qttools5-dev-tools, qtmultimedia5-dev, libqt5sql5-sqlite, libqt5sql5-psql, libqt5svg5-dev, libqt5multimedia5-plugins, doxygen]
 
+    configflags:
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DDO_RELEASE_BUILD=ON
     stage-packages:
      - libasyncns0
      - libdouble-conversion1
@@ -71,3 +75,9 @@ parts:
      - libxcb1
      - libxdmcp6
      - sqlitebrowser
+
+layout:
+  /usr/share/brewtarget:
+    symlink: $SNAP/usr/share/brewtarget
+  /usr/share/doc/brewtarget:
+    symlink: $SNAP/usr/share/doc/brewtarget

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,7 +34,7 @@ parts:
       - bin/*
   my-part:
     # See 'snapcraft plugins'
-    source: https://github.com/padraic7a/brewtarget.git
+    source: .
   #source-branch: devel
     plugin: cmake
     build-packages: [g++, cmake, git, qtbase5-dev, qttools5-dev, qttools5-dev-tools, qtmultimedia5-dev, libqt5sql5-sqlite, libqt5sql5-psql, libqt5svg5-dev, libqt5multimedia5-plugins, doxygen]


### PR DESCRIPTION
08ffa42d87de21d024b43c6ed910a69e19f9f741      - puts snapcraft.yaml into a snap directory
12b97cbd5b98ea680f475e9546d8d7001037a21f    - changes snap confinement to 'strict' for educational purposes
a0fb2314d8997b08c79d2f2da3383aa0d30ee2d6    - adds the 'openegl' plug to suppress libgl errors
                                                                                  - removes the github repo details from parts/my-part/source. Is this unnecessary now with snapcraft.yaml being located in the snap directory?
                                                                                  - adds a ```config-flags``` section:
                                                                                  - ```DO_RELEASE_BUILD - ON```. If ON, will do a release build. 
                                                                                  - ``` CMAKE_INSTALL_PREFIX=/usr``` listed in the README as being for Debian based systems
                                                                                 - adds a ```layout``` section which includes symlinks that locate the default database.