### PR TITLE
Fix icon rendering

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -75,6 +75,7 @@ parts:
      - libxcb1
      - libxdmcp6
      - sqlitebrowser
+     - libqt5svg5
 
 layout:
   /usr/share/brewtarget:


### PR DESCRIPTION
Adding in missing package. I was missing ```libqt5svg5```, even though I had built with ```libqt5svg5-dev```.
["If you build the package normally, when you add the -dev files they automatically pull in the libraries themselves. However, when you build on snapcraft, the libraries are not automatically added to the stage packages."]